### PR TITLE
copy link ui improved

### DIFF
--- a/src/components/ui/Share.tsx
+++ b/src/components/ui/Share.tsx
@@ -18,6 +18,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "./button";
+import { useState } from "react";
 
 type ShareProps = {
   shareurl: string;
@@ -25,6 +26,8 @@ type ShareProps = {
 };
 
 const Share = ({ shareurl, handleShare }: ShareProps) => {
+
+  const [urlCopied, setUrlCopied] = useState(false);
   const data = [
     {
       label: "Facebook",
@@ -111,8 +114,9 @@ const Share = ({ shareurl, handleShare }: ShareProps) => {
               value={shareurl}
             ></input>
             <Button
-              className="bg-white"
+              className={urlCopied ? 'bg-green-400' : 'bg-white'}
               onClick={() => {
+                setUrlCopied(true);
                 window.navigator.clipboard.writeText(shareurl);
               }}
             >


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes #58 

Issue: There was no change in ui after the copy link button was clicked, which could cause confusion among the users whether the link was copied or not.

## Screenshots
Before Clicking on Copy Link Button:
![Screenshot 2024-05-14 133440](https://github.com/Nishitbaria/OpenGrame/assets/123577873/baa21227-c33a-4c4e-8e36-3b237d8a5822)

After Clicking on Copy Link Button:
![Screenshot 2024-05-14 133521](https://github.com/Nishitbaria/OpenGrame/assets/123577873/121f83e8-fc42-4648-b22d-23dad9280262)


