### PR TITLE
Fix the scrolling in signup form and added show password eye icon in both Sign up and Login form.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -511,23 +511,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
@@ -2274,13 +2257,13 @@
       "version": "15.7.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
       "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
       "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2290,7 +2273,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2990,7 +2973,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/src/_auth/forms/SigninForm.tsx
+++ b/src/_auth/forms/SigninForm.tsx
@@ -17,8 +17,11 @@ import Loader from "../../components/shared/Loader";
 import { Link, useNavigate } from "react-router-dom";
 import { useSignInAccount } from "@/lib/react-query/queriesAndMutations.js";
 import { useUserContext } from "@/context/AuthContext.js";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
 
 const SigninForm = () => {
+  const [showPassword, setShowPassword] = useState(false);
   const form = useForm<z.infer<typeof SigninValidation>>({
     resolver: zodResolver(SigninValidation),
     defaultValues: {
@@ -96,9 +99,19 @@ const SigninForm = () => {
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="shad-form_label">Password</FormLabel>
-                <FormControl>
-                  <Input type="password" className="shad-input" {...field} />
+                <div className="relative">
+              <FormControl>
+                  <Input type={showPassword? "text" :"password" } className="shad-input" {...field} />
                 </FormControl>
+                <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                    >
+                     {showPassword ? <EyeOff />: <Eye/> }
+                    </button>
+              </div>
+          
                 <FormMessage />
               </FormItem>
             )}

--- a/src/_auth/forms/SignupForm.tsx
+++ b/src/_auth/forms/SignupForm.tsx
@@ -20,8 +20,11 @@ import {
   useSignInAccount,
 } from "@/lib/react-query/queriesAndMutations.js";
 import { useUserContext } from "@/context/AuthContext.js";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
 
 const SignupForm = () => {
+  const [showPassword, setShowPassword] = useState(false);
   const form = useForm<z.infer<typeof SignupValidation>>({
     resolver: zodResolver(SignupValidation),
     defaultValues: {
@@ -77,9 +80,9 @@ const SignupForm = () => {
 
   return (
     <Form {...form}>
-      <div className=" sm:w-420 flex-center  flex-col mt-10 ">
+      <div className=" sm:w-420 flex-center   flex-col mt-7 ">
         <img src="/assets/images/logo.svg" />
-        <h2 className="h3-bold md:h2:bold text-white pt-5 md:pt-12">
+        <h2 className="h3-bold md:h2:bold text-white pt-5 md:pt-10">
           {" "}
           Create New Account{" "}
         </h2>
@@ -88,7 +91,7 @@ const SignupForm = () => {
         </p>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="flex flex-col gap-5 w-full mt-5"
+          className="flex flex-col gap-2 w-full mt-5"
         >
           <FormField
             control={form.control}
@@ -138,9 +141,18 @@ const SignupForm = () => {
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="shad-form_label">Password</FormLabel>
-                <FormControl>
-                  <Input type="password" className="shad-input" {...field} />
+              <div className="relative">
+              <FormControl>
+                  <Input type={showPassword? "text" :"password" } className="shad-input" {...field} />
                 </FormControl>
+                <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                    >
+                     {showPassword ? <EyeOff />: <Eye/> }
+                    </button>
+              </div>
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION

## Fixes Issue
Closes #79

## Changes proposed
- Decrease the spacing between the form fields  in sign-up form to accommodate all content comes on single page..
- Introduced show/hide icon functionality for the password field, enhancing user experience and security.
## Screenshots
- I am attaching video to show what are the changes showing on the OpenGrame.

https://github.com/Nishitbaria/OpenGrame/assets/134795697/98ab103b-421c-4681-a440-18c40c8a74b4



## Note to reviewers
- Scrolling was retained in the sign-up form to manage dynamic height adjustments. For instance, if a user enters a username shorter than 2 characters, a password shorter than 8 characters, or an incorrect email format, error messages appear beneath the relevant fields. These messages increase the form's height, necessitating the need for scrolling to ensure all content remains accessible.
